### PR TITLE
chore: update golang version to 1.18 to support generics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/FornaxDB/fornaxdb
 
-go 1.17
+go 1.18
 
 require (
 	github.com/joomcode/errorx v1.0.3 // indirect


### PR DESCRIPTION
Fixes #8 